### PR TITLE
Fix assigned_value KeyError in modification

### DIFF
--- a/modification/dhw_functions.py
+++ b/modification/dhw_functions.py
@@ -111,7 +111,11 @@ def parse_building_dhw_params(df_bldg):
 
     for row in df_bldg.itertuples():
         name = row.param_name
-        val  = row.assigned_value
+        # Accept both 'assigned_value' (raw CSV) and 'param_value' (structured CSV)
+        if hasattr(row, "assigned_value"):
+            val = row.assigned_value
+        else:
+            val = row.param_value
 
         if name.endswith("_range"):
             base_name = name.replace("_range", "")

--- a/modification/elec_functions.py
+++ b/modification/elec_functions.py
@@ -65,7 +65,11 @@ def create_elec_scenarios(
             obj_name = row.object_name
             p_name   = row.param_name
 
-            base_val = row.assigned_value
+            # Input CSVs may use 'assigned_value' or already rename to 'param_value'
+            if hasattr(row, "assigned_value"):
+                base_val = row.assigned_value
+            else:
+                base_val = row.param_value
             p_min    = row.min_val
             p_max    = row.max_val
 

--- a/modification/equipment_functions.py
+++ b/modification/equipment_functions.py
@@ -60,7 +60,12 @@ def create_equipment_scenarios(
     rows = []
     for s in range(num_scenarios):
         for row in df_bldg.itertuples():
-            base_val = row.assigned_value
+            # Equipment CSV may store the chosen value under 'assigned_value'
+            # or 'param_value' depending on preprocessing.
+            if hasattr(row, "assigned_value"):
+                base_val = row.assigned_value
+            else:
+                base_val = row.param_value
             p_min = getattr(row, "min_val", None)
             p_max = getattr(row, "max_val", None)
             new_val = pick_value(base_val, p_min, p_max, picking_method)

--- a/modification/hvac_functions.py
+++ b/modification/hvac_functions.py
@@ -151,7 +151,12 @@ def parse_building_hvac_params(df_bldg):
         # The CSV from the assignment step uses 'assigned_value'
         # rather than 'param_value'.  We read that column here so
         # the function works with the raw assigned CSV.
-        val  = row.assigned_value
+        # Support both raw assigned CSVs (assigned_value column)
+        # and structured CSVs (param_value column)
+        if hasattr(row, "assigned_value"):
+            val = row.assigned_value
+        else:
+            val = row.param_value
 
         if name.endswith("_range"):
             base_name = name.replace("_range", "")
@@ -195,7 +200,10 @@ def parse_zone_hvac_params(df_zone):
         # The assigned HVAC CSV stores the picked values under
         # the column 'assigned_value'.  Use that column here so we
         # don't raise an AttributeError when parsing the raw file.
-        val   = row.assigned_value
+        if hasattr(row, "assigned_value"):
+            val = row.assigned_value
+        else:
+            val = row.param_value
 
         results.append({
             "zone_name": zname,


### PR DESCRIPTION
## Summary
- support structured CSVs in modification functions
- fall back to `param_value` when `assigned_value` is missing

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '__pycache__')`

------
https://chatgpt.com/codex/tasks/task_e_6846df8122e0832a9b8f17988b224dca