### PR TITLE
Handle missing IDF objects gracefully

### DIFF
--- a/idf_objects/fenez/materials.py
+++ b/idf_objects/fenez/materials.py
@@ -150,10 +150,14 @@ def update_construction_materials(
         "MATERIAL:NOMASS",
         "WINDOWMATERIAL:GLAZING",
         "WINDOWMATERIAL:SIMPLEGLAZINGSYSTEM",
-        "CONSTRUCTION"
+        "CONSTRUCTION",
     ]:
         for obj in idf.idfobjects[obj_type][:]:
-            idf.removeidfobject(obj)
+            try:
+                idf.removeidfobject(obj)
+            except ValueError:
+                # Object might have been removed earlier; ignore
+                pass
 
     def create_opaque_material(idf_obj, mat_data, mat_name):
         """
@@ -172,7 +176,10 @@ def update_construction_materials(
         if mat_type in ["MATERIAL", "MATERIAL:NOMASS"]:
             for obj in idf_obj.idfobjects[mat_type]:
                 if obj.Name == mat_name:
-                    idf_obj.removeidfobject(obj)
+                    try:
+                        idf_obj.removeidfobject(obj)
+                    except ValueError:
+                        pass
 
         if mat_type == "MATERIAL":
             mat_obj = idf_obj.newidfobject("MATERIAL")
@@ -213,7 +220,10 @@ def update_construction_materials(
         if wtype in ["WINDOWMATERIAL:GLAZING", "WINDOWMATERIAL:SIMPLEGLAZINGSYSTEM"]:
             for obj in idf_obj.idfobjects[wtype]:
                 if obj.Name == mat_name:
-                    idf_obj.removeidfobject(obj)
+                    try:
+                        idf_obj.removeidfobject(obj)
+                    except ValueError:
+                        pass
 
         if wtype == "WINDOWMATERIAL:GLAZING":
             wmat = idf_obj.newidfobject("WINDOWMATERIAL:GLAZING")

--- a/idf_objects/tempground/add_ground_temperatures.py
+++ b/idf_objects/tempground/add_ground_temperatures.py
@@ -18,7 +18,11 @@ def add_ground_temperatures(
     # Remove existing ground temperature objects
     existing_ground_temps = idf.idfobjects["SITE:GROUNDTEMPERATURE:BUILDINGSURFACE"]
     for temp in existing_ground_temps[:]:
-        idf.removeidfobject(temp)
+        try:
+            idf.removeidfobject(temp)
+        except ValueError:
+            # Ignore if the object was already removed
+            pass
 
     # 1) Assign new monthly temps
     final_temps = assign_ground_temperatures(


### PR DESCRIPTION
## Summary
- avoid ValueError when removing IDF objects multiple times
- handle removal issues for ground temperature objects as well

## Testing
- `python -m py_compile idf_objects/fenez/materials.py idf_objects/tempground/add_ground_temperatures.py`

------
https://chatgpt.com/codex/tasks/task_e_68471692da94832abb92b47b3a664806