### PR TITLE
Add ogc_fid column to shading log

### DIFF
--- a/idf_creation.py
+++ b/idf_creation.py
@@ -722,12 +722,14 @@ def _write_shading_csv(assigned_shading_log, logs_base_dir):
         strategy = data_for_window.get("strategy_used", "")
         control_name = data_for_window.get("shading_control_name_assigned", "")
         blind_mat_name = data_for_window.get("blind_material_name_used", "")
+        bldg_id = data_for_window.get("ogc_fid")
 
         if not shading_params and not status:
             continue
 
         base_row_info = {
             "window_id": window_id,
+            "ogc_fid": bldg_id,
             "shading_type_key": type_key,
             "strategy": strategy,
             "creation_status": status,

--- a/idf_objects/wshading/create_shading_objects.py
+++ b/idf_objects/wshading/create_shading_objects.py
@@ -89,6 +89,13 @@ def add_shading_objects(
     if random_seed is not None:
         random.seed(random_seed)
 
+    bldg_id = None
+    if building_row is not None:
+        try:
+            bldg_id = building_row.get("ogc_fid")
+        except AttributeError:
+            bldg_id = getattr(building_row, "ogc_fid", None)
+
     if not idf:
         logger.error("IDF object is None. Cannot add shading objects.")
         return
@@ -137,7 +144,9 @@ def add_shading_objects(
                     )
                     if assigned_shading_log is not None:
                         if window_id not in assigned_shading_log:
-                            assigned_shading_log[window_id] = {}
+                            assigned_shading_log[window_id] = {"ogc_fid": bldg_id}
+                        else:
+                            assigned_shading_log[window_id].setdefault("ogc_fid", bldg_id)
                         assigned_shading_log[window_id]["shading_creation_status"] = f"Failed: No params for key {shading_type_key}"
                     continue
 
@@ -230,7 +239,9 @@ def add_shading_objects(
                     )
                     if assigned_shading_log is not None:
                         if window_id not in assigned_shading_log:
-                            assigned_shading_log[window_id] = {}
+                            assigned_shading_log[window_id] = {"ogc_fid": bldg_id}
+                        else:
+                            assigned_shading_log[window_id].setdefault("ogc_fid", bldg_id)
                         assigned_shading_log[window_id][
                             "shading_creation_status"
                         ] = "Failed: Zone Name for ShadingControl could not be determined."
@@ -312,7 +323,9 @@ def add_shading_objects(
                 # Log final success for this fenestration
                 if assigned_shading_log is not None:
                     if window_id not in assigned_shading_log:
-                        assigned_shading_log[window_id] = {}
+                        assigned_shading_log[window_id] = {"ogc_fid": bldg_id}
+                    else:
+                        assigned_shading_log[window_id].setdefault("ogc_fid", bldg_id)
                     assigned_shading_log[window_id][
                         "shading_creation_status"
                     ] = f"Linked to {shading_ctrl_name}"
@@ -330,7 +343,9 @@ def add_shading_objects(
                 )
                 if assigned_shading_log is not None:
                     if window_id not in assigned_shading_log:
-                        assigned_shading_log[window_id] = {}
+                        assigned_shading_log[window_id] = {"ogc_fid": bldg_id}
+                    else:
+                        assigned_shading_log[window_id].setdefault("ogc_fid", bldg_id)
                     assigned_shading_log[window_id][
                         "shading_creation_status"
                     ] = f"Failed: Outer processing error - {str(e_fen_processing)}"


### PR DESCRIPTION
## Summary
- capture building ID when logging shading data
- include `ogc_fid` column when writing shading log CSV

## Testing
- `python -m py_compile idf_creation.py idf_objects/wshading/create_shading_objects.py`

------
https://chatgpt.com/codex/tasks/task_e_684762dca0b4832aa4f09a937cc5c53f